### PR TITLE
Clean up ViewModels and Login

### DIFF
--- a/TJS.VIMS/TJS.VIMS/Controllers/AccountController.cs
+++ b/TJS.VIMS/TJS.VIMS/Controllers/AccountController.cs
@@ -99,7 +99,7 @@ namespace TJS.VIMS.Controllers
         [HttpPost]
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult> Login(LoginViewModel model, string returnUrl)
+        public async Task<ActionResult> Login(LogInViewModel model, string returnUrl)
         {
             if (!ModelState.IsValid)
             {
@@ -108,7 +108,9 @@ namespace TJS.VIMS.Controllers
 
             // This doesn't count login failures towards account lockout
             // To enable password failures to trigger account lockout, change to shouldLockout: true
-            var result = await SignInManager.PasswordSignInAsync(model.UserName, model.Password, model.RememberMe, shouldLockout: false);
+            // JS: model.rememberMe seems unused, effectively commenting it out for now.
+            var rememberMe = false;
+            var result = await SignInManager.PasswordSignInAsync(model.UserName, model.Password, rememberMe, shouldLockout: false);
             switch (result)
             {
                 case SignInStatus.Success:

--- a/TJS.VIMS/TJS.VIMS/ViewModel/AccountViewModels.cs
+++ b/TJS.VIMS/TJS.VIMS/ViewModel/AccountViewModels.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
-namespace TJS.VIMS.Models
+namespace TJS.VIMS.ViewModel
 {
     public class ExternalLoginConfirmationViewModel
     {

--- a/TJS.VIMS/TJS.VIMS/ViewModel/ManageViewModels.cs
+++ b/TJS.VIMS/TJS.VIMS/ViewModel/ManageViewModels.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNet.Identity;
 using Microsoft.Owin.Security;
 
-namespace TJS.VIMS.Models
+namespace TJS.VIMS.ViewModel
 {
     public class IndexViewModel
     {


### PR DESCRIPTION
- Some ViewModels were in the Models package instead of ViewModels.  Finished moving them over.
- Failed logins would result in a stack trace due to referencing an old LoginViewModel class.  Fixed.